### PR TITLE
remove Programming language classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,6 @@ classifiers = [
   "Intended Audience :: Developers",
   "Natural Language :: English",
   "Environment :: Console",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
 ]
 
 [tool.poetry.plugins."sceptre.hooks"]


### PR DESCRIPTION
We don't need to manually specify programming language classifiers because poetry will auto generate them.